### PR TITLE
Bugfix: Could not instantiated extension

### DIFF
--- a/applications/mne_analyze/extensions/deepcntk/deepcntk.pro
+++ b/applications/mne_analyze/extensions/deepcntk/deepcntk.pro
@@ -77,7 +77,8 @@ else {
             -lCntk.Core-2.0
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     deepcntk.cpp \

--- a/applications/mne_analyze/extensions/deepcntknets/dnn/dnn.pro
+++ b/applications/mne_analyze/extensions/deepcntknets/dnn/dnn.pro
@@ -78,7 +78,8 @@ else {
             -ldeepcntk
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
 
 SOURCES += \
     dnn.cpp

--- a/applications/mne_analyze/extensions/deepcntknets/fnn/fnn.pro
+++ b/applications/mne_analyze/extensions/deepcntknets/fnn/fnn.pro
@@ -78,7 +78,8 @@ else {
             -ldeepcntk
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions/deepcntknets
 
 SOURCES += \
     fnn.cpp

--- a/applications/mne_analyze/extensions/dipolefit/dipolefit.pro
+++ b/applications/mne_analyze/extensions/dipolefit/dipolefit.pro
@@ -64,7 +64,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     dipolefit.cpp \

--- a/applications/mne_analyze/extensions/fiffio/fiffio.pro
+++ b/applications/mne_analyze/extensions/fiffio/fiffio.pro
@@ -70,7 +70,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     fiffio.cpp

--- a/applications/mne_analyze/extensions/invmne/invmne.pro
+++ b/applications/mne_analyze/extensions/invmne/invmne.pro
@@ -68,7 +68,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     invmne.cpp \

--- a/applications/mne_analyze/extensions/mainviewer/centralview.h
+++ b/applications/mne_analyze/extensions/mainviewer/centralview.h
@@ -101,7 +101,7 @@ public:
     /**
     * Default destructor
     */
-    ~CentralView();
+    ~CentralView() = default;
 protected:
 
 private:

--- a/applications/mne_analyze/extensions/mainviewer/mainviewer.cpp
+++ b/applications/mne_analyze/extensions/mainviewer/mainviewer.cpp
@@ -140,13 +140,14 @@ QMenu *MainViewer::getMenu()
 
 QDockWidget *MainViewer::getControl()
 {
-    if(!m_pControl) {
-        m_pControl = new QDockWidget(tr("Surfer Control"));
-        m_pControl->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
-        m_pControl->setMinimumWidth(180);
-    }
+//    if(!m_pControl) {
+//        m_pControl = new QDockWidget(tr("Surfer Control"));
+//        m_pControl->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::RightDockWidgetArea);
+//        m_pControl->setMinimumWidth(180);
+//    }
 
-    return m_pControl;
+//    return m_pControl;
+    return nullptr;
 }
 
 
@@ -166,6 +167,7 @@ QWidget *MainViewer::getView()
 
     return m_pView;
     */
+    return nullptr;
 }
 
 

--- a/applications/mne_analyze/extensions/mainviewer/mainviewer.pro
+++ b/applications/mne_analyze/extensions/mainviewer/mainviewer.pro
@@ -75,7 +75,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     mainviewer.cpp \

--- a/applications/mne_analyze/extensions/music/music.pro
+++ b/applications/mne_analyze/extensions/music/music.pro
@@ -68,7 +68,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     music.cpp \

--- a/applications/mne_analyze/extensions/stcbrowser/stcbrowser.pro
+++ b/applications/mne_analyze/extensions/stcbrowser/stcbrowser.pro
@@ -64,7 +64,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     stcbrowser.cpp \

--- a/applications/mne_analyze/extensions/surfer/surfer.pro
+++ b/applications/mne_analyze/extensions/surfer/surfer.pro
@@ -74,7 +74,8 @@ else {
             -lanShared
 }
 
-DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+win32: DLLDESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
+unix: DESTDIR = $${MNE_BINARY_DIR}/mne_analyze_extensions
 
 SOURCES += \
     surfer.cpp \

--- a/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
@@ -96,7 +96,6 @@ void ExtensionManager::loadExtension(const QString& dir)
         fprintf(stderr,"Loading Extension %s... ",file.toUtf8().constData());
 
         this->setFileName(extensionsDir.absoluteFilePath(file));
-        this->load();
         QObject *pExtension = this->instance();
 
         // IExtension

--- a/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
+++ b/applications/mne_analyze/libs/anShared/Management/extensionmanager.cpp
@@ -96,7 +96,7 @@ void ExtensionManager::loadExtension(const QString& dir)
         fprintf(stderr,"Loading Extension %s... ",file.toUtf8().constData());
 
         this->setFileName(extensionsDir.absoluteFilePath(file));
-        std::cout << this->load() << std::endl;
+        this->load();
         QObject *pExtension = this->instance();
 
         // IExtension


### PR DESCRIPTION
Fixed the extension could not be instantiated bug.The reason was: Building on Linux does not detect build errors in extensions =(.
On Windows only dll's are now stored in the extension directory.
